### PR TITLE
Make epoch and content type opaque

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -541,7 +541,6 @@ func (pt MLSPlaintext) commitAuthData() ([]byte, error) {
 type MLSCiphertext struct {
 	GroupID             []byte `tls:"head=1"`
 	Epoch               Epoch
-	ContentType         ContentType
 	SenderDataNonce     []byte `tls:"head=1"`
 	EncryptedSenderData []byte `tls:"head=1"`
 	AuthenticatedData   []byte `tls:"head=4"`

--- a/messages.go
+++ b/messages.go
@@ -456,7 +456,6 @@ func (c *MLSPlaintextContent) UnmarshalTLS(data []byte) (int, error) {
 }
 
 type MLSPlaintext struct {
-	GroupID           []byte `tls:"head=1"`
 	Epoch             Epoch
 	Sender            Sender
 	AuthenticatedData []byte `tls:"head=4"`
@@ -472,13 +471,11 @@ func (pt MLSPlaintext) toBeSigned(ctx GroupContext) []byte {
 	}
 
 	err = s.Write(struct {
-		GroupID           []byte `tls:"head=1"`
 		Epoch             Epoch
 		Sender            Sender
 		AuthenticatedData []byte `tls:"head=4"`
 		Content           MLSPlaintextContent
 	}{
-		GroupID:           pt.GroupID,
 		Epoch:             pt.Epoch,
 		Sender:            pt.Sender,
 		AuthenticatedData: pt.AuthenticatedData,
@@ -509,13 +506,11 @@ func (pt *MLSPlaintext) verify(ctx GroupContext, pub *SignaturePublicKey, scheme
 
 func (pt MLSPlaintext) commitContent() []byte {
 	enc, err := syntax.Marshal(struct {
-		GroupId     []byte `tls:"head=1"`
 		Epoch       Epoch
 		Sender      Sender
 		Commit      Commit
 		ContentType ContentType
 	}{
-		GroupId:     pt.GroupID,
 		Epoch:       pt.Epoch,
 		Sender:      pt.Sender,
 		Commit:      pt.Content.Commit.Commit,
@@ -539,7 +534,6 @@ func (pt MLSPlaintext) commitAuthData() ([]byte, error) {
 }
 
 type MLSCiphertext struct {
-	GroupID             []byte `tls:"head=1"`
 	Epoch               Epoch
 	SenderDataNonce     []byte `tls:"head=1"`
 	EncryptedSenderData []byte `tls:"head=1"`

--- a/messages_test.go
+++ b/messages_test.go
@@ -139,7 +139,6 @@ var (
 	mlsCiphertextIn = &MLSCiphertext{
 		GroupID:             []byte{0x01, 0x02, 0x03, 0x04},
 		Epoch:               1,
-		ContentType:         1,
 		AuthenticatedData:   []byte{0xAA, 0xBB, 0xCC},
 		SenderDataNonce:     []byte{0x01, 0x02},
 		EncryptedSenderData: []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
@@ -492,7 +491,6 @@ func generateMessageVectors(t *testing.T) []byte {
 		ct := MLSCiphertext{
 			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
-			ContentType:         ContentTypeApplication,
 			SenderDataNonce:     tv.Random,
 			EncryptedSenderData: tv.Random,
 			AuthenticatedData:   tv.Random,
@@ -695,7 +693,6 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		ct := MLSCiphertext{
 			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
-			ContentType:         ContentTypeApplication,
 			SenderDataNonce:     tv.Random,
 			EncryptedSenderData: tv.Random,
 			AuthenticatedData:   tv.Random,

--- a/messages_test.go
+++ b/messages_test.go
@@ -97,7 +97,6 @@ var (
 	}
 
 	mlsPlaintextIn = &MLSPlaintext{
-		GroupID:           []byte{0x01, 0x02, 0x03, 0x04},
 		Epoch:             1,
 		Sender:            Sender{SenderTypeMember, 4},
 		AuthenticatedData: []byte{0xAA, 0xBB, 0xcc, 0xdd},
@@ -110,7 +109,6 @@ var (
 	}
 
 	mlsPlaintextCommitIn = &MLSPlaintext{
-		GroupID:           []byte{0x01, 0x02, 0x03, 0x04},
 		Epoch:             1,
 		Sender:            Sender{SenderTypeMember, 4},
 		AuthenticatedData: []byte{0xAA, 0xBB, 0xcc, 0xdd},
@@ -126,7 +124,6 @@ var (
 	}
 
 	mlsPlaintextProposalIn = &MLSPlaintext{
-		GroupID:           []byte{0x01, 0x02, 0x03, 0x04},
 		Epoch:             1,
 		Sender:            Sender{SenderTypeMember, 4},
 		AuthenticatedData: []byte{0xAA, 0xBB, 0xcc, 0xdd},
@@ -137,7 +134,6 @@ var (
 	}
 
 	mlsCiphertextIn = &MLSCiphertext{
-		GroupID:             []byte{0x01, 0x02, 0x03, 0x04},
 		Epoch:               1,
 		AuthenticatedData:   []byte{0xAA, 0xBB, 0xCC},
 		SenderDataNonce:     []byte{0x01, 0x02},
@@ -425,9 +421,8 @@ func generateMessageVectors(t *testing.T) []byte {
 		}
 
 		addHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: addProposal,
 			},
@@ -444,9 +439,8 @@ func generateMessageVectors(t *testing.T) []byte {
 		}
 
 		updateHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: updateProposal,
 			},
@@ -463,9 +457,8 @@ func generateMessageVectors(t *testing.T) []byte {
 		}
 
 		removeHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: removeProposal,
 			},
@@ -489,7 +482,6 @@ func generateMessageVectors(t *testing.T) []byte {
 
 		//MlsCiphertext
 		ct := MLSCiphertext{
-			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
 			SenderDataNonce:     tv.Random,
 			EncryptedSenderData: tv.Random,
@@ -619,9 +611,8 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		}
 
 		addHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: addProposal,
 			},
@@ -639,9 +630,8 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		}
 
 		updateHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: updateProposal,
 			},
@@ -659,9 +649,8 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 		}
 
 		removeHs := MLSPlaintext{
-			GroupID: tv.GroupID,
-			Epoch:   tv.Epoch,
-			Sender:  Sender{tv.SenderType, uint32(tv.SignerIndex)},
+			Epoch:  tv.Epoch,
+			Sender: Sender{tv.SenderType, uint32(tv.SignerIndex)},
 			Content: MLSPlaintextContent{
 				Proposal: removeProposal,
 			},
@@ -691,7 +680,6 @@ func verifyMessageVectors(t *testing.T, data []byte) {
 
 		//MlsCiphertext
 		ct := MLSCiphertext{
-			GroupID:             tv.GroupID,
 			Epoch:               tv.Epoch,
 			SenderDataNonce:     tv.Random,
 			EncryptedSenderData: tv.Random,


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-protocol/pull/349.  Moves content type within sender data and randomly generates epoch values.